### PR TITLE
Retry on 429s

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -393,12 +393,10 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 							if timeSleepHeader, err := strconv.Atoi(res.Header.Get("Retry-After")); err == nil && timeSleepHeader > 0 && time.Duration(timeSleepHeader) < timeSleep {
 								timeSleep = time.Duration(timeSleepHeader)
 							}
-							c.logf("crawler: sleeping for %v before retrying for %v", timeSleep, url)
 							select {
 							case <-clonedReq.Context().Done():
 								c.logf("crawler: aborted because context done")
 							case <-time.After(timeSleep):
-								c.logf("crawler: retrying for %v after sleeping for %v", url, timeSleep)
 								c.Crawl(clonedReq)
 							}
 							return

--- a/crawler.go
+++ b/crawler.go
@@ -370,8 +370,11 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 						}()
 
 						var recrawl bool
-						if len(c.RetryHTTPResponseCodes) > 0 && c.urlNumRetries != nil {
+						if len(c.RetryHTTPResponseCodes) > 0 {
 							c.urlNumRetriesMu.Lock()
+							if c.urlNumRetries == nil {
+								c.urlNumRetries = make(map[string]int)
+							}
 							for _, v := range c.RetryHTTPResponseCodes {
 								if res.StatusCode != v {
 									continue

--- a/crawler.go
+++ b/crawler.go
@@ -344,11 +344,8 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 						// TODO(vivek): Should I respect Retry-After perfectly?
 						if res.StatusCode == http.StatusTooManyRequests {
 							timeSleep := 10
-							for _, val := range res.Header[http.CanonicalHeaderKey("Retry-After")] {
-								if timeSleepHeader, err := strconv.Atoi(val); err == nil && timeSleepHeader > 0 && timeSleepHeader < timeSleep {
-									timeSleep = timeSleepHeader
-								}
-								break
+							if timeSleepHeader, err := strconv.Atoi(res.Header.Get("Retry-After")); err == nil && timeSleepHeader > 0 && timeSleepHeader < timeSleep {
+								timeSleep = timeSleepHeader
 							}
 							time.Sleep(time.Second * time.Duration(timeSleep))
 							c.Crawl(clonedReq)

--- a/crawler.go
+++ b/crawler.go
@@ -340,10 +340,12 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 								c.logf("crawler: Handler got panic error: %v", r)
 							}
 						}()
+						// TODO(vivek): Don't want to retry forever. How should I escape out?
+						// TODO(vivek): Should I respect Retry-After perfectly?
 						if res.StatusCode == http.StatusTooManyRequests {
 							timeSleep := 10
 							for _, val := range res.Header[http.CanonicalHeaderKey("Retry-After")] {
-								if timeSleepHeader, err := strconv.Atoi(val); err == nil && timeSleepHeader < timeSleep {
+								if timeSleepHeader, err := strconv.Atoi(val); err == nil && timeSleepHeader > 0 && timeSleepHeader < timeSleep {
 									timeSleep = timeSleepHeader
 								}
 								break

--- a/crawler.go
+++ b/crawler.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -329,21 +330,34 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 			spider.reqch <- requestAndChan{req: req, ch: resc}
 			select {
 			case re := <-resc:
-				closeRequest(req)
 				if re.err != nil {
 					c.logf("crawler: send HTTP request got error: %v", re.err)
 				} else {
-					go func(res *http.Response) {
+					go func(clonedReq *http.Request, res *http.Response) {
 						defer closeResponse(res)
 						defer func() {
 							if r := recover(); r != nil {
 								c.logf("crawler: Handler got panic error: %v", r)
 							}
 						}()
+						if res.StatusCode == http.StatusTooManyRequests {
+							timeSleep := 10
+							for _, val := range res.Header[http.CanonicalHeaderKey("Retry-After")] {
+								if timeSleepHeader, err := strconv.Atoi(val); err == nil && timeSleepHeader < timeSleep {
+									timeSleep = timeSleepHeader
+								}
+								break
+							}
+							time.Sleep(time.Second * time.Duration(timeSleep))
+							c.Crawl(clonedReq)
+							return
+						}
+						closeRequest(clonedReq)
 						h, _ := c.Handler(res)
 						h.ServeSpider(c.writeCh, res)
-					}(re.res)
+					}(req.Clone(req.Context()), re.res)
 				}
+				closeRequest(req)
 			case <-closeCh:
 				closeRequest(req)
 				return

--- a/crawler.go
+++ b/crawler.go
@@ -393,11 +393,12 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 							if timeSleepHeader, err := strconv.Atoi(res.Header.Get("Retry-After")); err == nil && timeSleepHeader > 0 && time.Duration(timeSleepHeader) < timeSleep {
 								timeSleep = time.Duration(timeSleepHeader)
 							}
+							c.logf("crawler: sleeping for %v before retrying for %v", timeSleep, url)
 							select {
 							case <-clonedReq.Context().Done():
 								c.logf("crawler: aborted because context done")
 							case <-time.After(timeSleep):
-								c.logf("crawler: retrying for %v", url)
+								c.logf("crawler: retrying for %v after sleeping for %v", url, timeSleep)
 								c.Crawl(clonedReq)
 							}
 							return

--- a/crawler.go
+++ b/crawler.go
@@ -370,6 +370,7 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 						}()
 
 						var recrawl bool
+						url := clonedReq.URL.String()
 						if len(c.RetryHTTPResponseCodes) > 0 {
 							c.urlNumRetriesMu.Lock()
 							if c.urlNumRetries == nil {
@@ -379,7 +380,6 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 								if res.StatusCode != v {
 									continue
 								}
-								url := clonedReq.URL.String()
 								if val, _ := c.urlNumRetries[url]; val < c.maxRetries() {
 									c.urlNumRetries[url]++
 									recrawl = true
@@ -397,6 +397,7 @@ func (c *Crawler) scanRequestWork(workCh chan chan *http.Request, closeCh chan i
 							case <-clonedReq.Context().Done():
 								c.logf("crawler: aborted because context done")
 							case <-time.After(timeSleep):
+								c.logf("crawler: retrying for %v", url)
 								c.Crawl(clonedReq)
 							}
 							return


### PR DESCRIPTION
Ready for review now. The retry logic will hold off on "retrying for a URL thats constantly 429-ing" once it hits MaxRetries till a successful call resets the retries counter for that URL; otoh, the first call will go thru, allowing for the chance of the latter event. 